### PR TITLE
Flush Left Alignment for First Column w/ align = 'left'

### DIFF
--- a/jquery.wookmark.js
+++ b/jquery.wookmark.js
@@ -151,7 +151,12 @@
         // Postion the item.
         itemCSS.top = shortest + 'px';
 
-        sideOffset = (shortestIndex * columnWidth + offset) + 'px';
+        // stick to left side if alignment is left and this is the first column
+        if (shortestIndex == 0 && this.align == 'left') {
+            sideOffset = '0';
+        } else {
+            sideOffset = (shortestIndex * columnWidth + offset) + 'px';
+        }
         if (this.align == 'right') {
           itemCSS.right = sideOffset;
         } else {


### PR DESCRIPTION
Not sure about everyone else, but I assumed left-aligned would stick the item to the left, not pad it per the offset. Alternatively, I can add an additional option to control this behavior.
