### PR TITLE
Use first items width if itemWidth is set to 0.

### DIFF
--- a/jquery.wookmark.js
+++ b/jquery.wookmark.js
@@ -70,7 +70,7 @@
 
     // Method to get the standard item width
     Wookmark.prototype.getItemWidth = function() {
-      return this.itemWidth === undefined ? this.handler.eq(0).outerWidth() : this.itemWidth;
+      return this.itemWidth === undefined || this.itemWidth === 0 ? this.handler.eq(0).outerWidth() : this.itemWidth;
     };
 
     // Main layout methdd.


### PR DESCRIPTION
itemWidth defaults to 0 and from what I can tell it will never be undefined. Therefore if you don't pass in an itemWidth, all the tires seem to stack on top of each other.

This change allowed me to use % width tiles (#51) as well.
