### PR TITLE
fixed #133 Change to use "for" statement instead of "for-in" at Line 50.

### DIFF
--- a/jquery.wookmark.js
+++ b/jquery.wookmark.js
@@ -42,12 +42,12 @@
   };
 
   // Function for executing css writes to dom on the next animation frame if supported
-  var executeNextFrame = window.requestAnimationFrame || function(callback) {callback()};
+  var executeNextFrame = window.requestAnimationFrame || function(callback) {callback();};
 
   function bulkUpdateCSS(data) {
     executeNextFrame(function() {
       var i, item;
-      for (i in data) {
+      for (i = 0; i < data.length; i++) {
         item = data[i];
         item.obj.css(item.css);
       }


### PR DESCRIPTION
Change using "for" statement instead of "for-in" at line 50.
"for-in" loop use not only assoc-array but also prototype's elements.
The prototype's elements include function which do not have enough parameters.
It caused JS error.
