### PR TITLE
Fix in jquery dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,6 +9,6 @@
     "**/*.txt"
   ],
   "dependencies": {
-    "jQuery": ">=1.5.3"
+    "jquery": ">=1.5.3"
   }
 }


### PR DESCRIPTION
The caps in the "Q" breaks compatibility with other libraries. Should be all lowercase.
