### PR TITLE
[BUGFIX] Fixes getItemWidth when itemWidth is a function

### DIFF
--- a/wookmark.js
+++ b/wookmark.js
@@ -524,7 +524,7 @@
     if (this.items.length > 0 && (itemWidth === undefined || (itemWidth === 0 && !this.flexibleWidth))) {
       itemWidth = getWidth(this.items[0]);
     } else if (typeof itemWidth === 'string' && itemWidth.indexOf('%') >= 0) {
-      itemWidth = parseFloat(this.itemWidth) / 100 * innerWidth;
+      itemWidth = parseFloat(itemWidth) / 100 * innerWidth;
     }
 
     // Calculate flexible item width if option is set


### PR DESCRIPTION
Uses `itemWidth` instead of `this.itemWidth` to get the right value to parse in case `this.itemWidth` was a function.